### PR TITLE
Add middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@
 
 - Doesn't use **React Context** (but you can easily use it to provide a context-specific store!)
 - Provides a simple `set` function for updating a store and not much else (have you checked out the [demo] yet?) If you want to use **reducers** or libraries like [Immer], these can easily sit on top of your Statery store.
-- Currently no support for (or concept of) **middlewares**, but this may change in the future.
 - While the `useStore` hook makes use of **proxies**, the store contents themselves are never wrapped in proxy objects. (If you're looking for a fully proxy-based solution, I recommend [Valtio].)
 - **React Class Components** are not supported (but PRs welcome!)
 
@@ -224,6 +223,28 @@ const fetchPosts = async () => {
 }
 ```
 
+### Middleware
+Plug in your middleware in a glimpse to react to the store changes.
+> The middleware can either be sync or asynchronous
+
+```ts
+import { makeStore, applyMiddleware } from "statery"
+
+// Create a store
+const store = makeStore({ counter: 0 })
+
+// Create a logger middleware
+const middleware = (state) => console.log(state)
+// Create another middleware
+const middleware2 = (state) => localStorage.setItem('STATERY', JSON.stringify(state))
+
+// Apply your middleware
+applyMiddleware(store, middleware, middleware2);
+
+// Update your store
+store.set({ counter: 1 })
+```
+
 ### TypeScript support
 
 Statery is written in TypeScript, and its stores are fully typed. `useStore` knows about the structure of your store, and if you're about to update a store with a property that it doesn't know about, TypeScript will warn you.
@@ -240,7 +261,7 @@ store.set({ foo: 123 }) // 😭  TypeScript warning
 
 ### Stuff that probably needs work
 
-- [ ] No support for middleware yet. Haven't decided on an API that is adequately simple.
+- [x] No support for middleware yet. Haven't decided on an API that is adequately simple.
 - [ ] I have yet to try how Statery behaves in React's upcoming Concurrent Mode. It does work fine within React's StrictMode, though, so chances are it'll be okay.
 - [ ] Probably other bits and pieces I haven't even encountered yet.
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "rollup-plugin-typescript2": "^0.29.0",
     "ts-jest": "^26.4.4",
     "tslib": "^2.0.3",
+    "type-fest": "^0.21.3",
     "typedoc": "^0.20.1",
     "typescript": "^4.1.3"
   },

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1,4 +1,4 @@
-import { makeStore } from "../src"
+import { makeStore, applyMiddleware } from "../src"
 
 describe("makeStore", () => {
   const store = makeStore({
@@ -8,7 +8,7 @@ describe("makeStore", () => {
   })
 
   beforeEach(() => {
-    store.set({ foo: 0, bar: 0 })
+    store.set({ foo: 0, bar: 0, active: false })
   })
 
   describe(".state", () => {
@@ -132,6 +132,47 @@ describe("makeStore", () => {
 
       expect(prevValue).toBe(0)
       expect(newValue).toBe(1)
+    })
+
+    it("should call sync middleware", () => {
+      const middleware = jest.fn()
+
+      applyMiddleware(store, middleware)
+      store.set({ foo: 1 })
+
+      expect(middleware).toHaveBeenCalledWith({
+        foo: 1,
+        bar: 0,
+        active: false
+      })
+    })
+
+    it("should call async middleware", () => {
+      const middleware = jest.fn().mockImplementation(() => Promise.resolve())
+
+      applyMiddleware(store, middleware)
+      store.set({ foo: 1 })
+
+      expect(middleware).toHaveBeenCalledWith({
+        foo: 1,
+        bar: 0,
+        active: false
+      })
+    })
+
+    it("should call all middleware", () => {
+      const middlewares = [jest.fn(), jest.fn().mockImplementation(() => Promise.resolve())]
+
+      applyMiddleware.apply(null, [store, ...middlewares])
+      store.set({ foo: 1 })
+
+      middlewares.forEach((m) => {
+        expect(m).toHaveBeenCalledWith({
+          foo: 1,
+          bar: 0,
+          active: false
+        })
+      })
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3791,6 +3791,11 @@ type-fest@^0.11.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
 
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
 type-fest@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"


### PR DESCRIPTION
First of all I want to mention how amazing the simplicity of this library is. Both the dev experience and the documented source code is sublime.

### Info
- Add `applyMiddleware` functionality that takes in a `store` and `middleware`. This api does not require internal store code changes. In general this is just some syntactic suger for the `store.subscribe`.
- A `Middleware` can be either sync or async, each will be awaited anyway