### PR TITLE
`forceNotify` flag

### DIFF
--- a/.changeset/spotty-planets-begin.md
+++ b/.changeset/spotty-planets-begin.md
@@ -1,0 +1,5 @@
+---
+"statery": minor
+---
+
+`set` now takes a second argument `forceNotify`; when set to true, all updated properties will be notified, regardless of referential equality to the previous value.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,26 @@ const BuyHouseButton = () => {
 }
 ```
 
+### Forcing a store update
+
+Statery checks changes to the store's state by checking referential equality. In some cases, you may want to force a store update even though the property has not changed to a new object. For these situations, the `set` function allows you to pass a second argument; if this is set to `true`, Statery will ignore the equality check and notify all listeners to the properties included in the update.
+
+Example:
+
+```tsx
+const store = makeStore({
+  rotation: new THREE.Vector3()
+})
+
+export const randomizeRotation = () =>
+  store.set(
+    (state) => ({
+      rotation: state.rotation.randomRotation()
+    }),
+    true
+  )
+```
+
 ### Subscribing to updates (imperatively)
 
 Use a store's `subscribe` function to register a callback that will be executed every time the store is changed.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ const BuyHouseButton = () => {
 
 ### Forcing a store update
 
-Statery checks changes to the store's state by checking referential equality. In some cases, you may want to force a store update even though the property has not changed to a new object. For these situations, the `set` function allows you to pass a second argument; if this is set to `true`, Statery will ignore the equality check and notify all listeners to the properties included in the update.
+When the store is updated, Statery will check which of the properties within the update object are actually different objects (or scalar values) from the previous state, and will only notify listeners to those properties.
+
+In some cases, you may want to force a store update even though the property has not changed to a new object. For these situations, the `set` function allows you to pass a second argument; if this is set to `true`, Statery will ignore the equality check and notify all listeners to the properties included in the update.
 
 Example:
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -117,6 +117,25 @@ describe("makeStore", () => {
       store.unsubscribe(listener)
     })
 
+    it("receives all changes made to the store if the `force` flag is set", () => {
+      const listener = jest.fn()
+      store.subscribe(listener)
+
+      /* We're setting both foo and bar; only foo is actually a new value. */
+      store.set({ foo: 1, bar: 0 }, true)
+
+      /* Updates only contain props that have actually changed */
+      expect(listener.mock.calls[0][0]).toEqual({ foo: 1, bar: 0 })
+
+      /* The second argument is the previous state */
+      expect(listener.mock.calls[0][1]).toEqual({ foo: 0, bar: 0 })
+
+      /* The state has actually been updated */
+      expect(store.state).toEqual({ foo: 1, bar: 0 })
+
+      store.unsubscribe(listener)
+    })
+
     it("already makes the updated state available to listeners", () => {
       let newValue: number | undefined = undefined
       let prevValue: number | undefined = undefined

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1,14 +1,16 @@
 import { makeStore } from "../src"
 
 describe("makeStore", () => {
-  const store = makeStore({
+  const init = () => ({
     foo: 0,
     bar: 0,
     active: false
   })
 
+  const store = makeStore(init())
+
   beforeEach(() => {
-    store.set({ foo: 0, bar: 0 })
+    store.set(init)
   })
 
   describe(".state", () => {
@@ -124,14 +126,8 @@ describe("makeStore", () => {
       /* We're setting both foo and bar; only foo is actually a new value. */
       store.set({ foo: 1, bar: 0 }, true)
 
-      /* Updates only contain props that have actually changed */
+      /* Since we've forced the update, the changes now include the un-changed `bar`, as well */
       expect(listener.mock.calls[0][0]).toEqual({ foo: 1, bar: 0 })
-
-      /* The second argument is the previous state */
-      expect(listener.mock.calls[0][1]).toEqual({ foo: 0, bar: 0 })
-
-      /* The state has actually been updated */
-      expect(store.state).toEqual({ foo: 1, bar: 0 })
 
       store.unsubscribe(listener)
     })


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/hmans/statery/force-notify-flag?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=hmans&repo=statery&branch=force-notify-flag">VS Code</a>

<!-- open-in-codesandbox:complete -->


Allows us to notify listeners for updated properties even when the object reference is the same as before.