### PR TITLE
Move useStore listener creation into render stage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -187,7 +187,9 @@ export const useStore = <T extends State>(store: Store<T>): T => {
 
   /* On unmount, remove the listener from the store. */
   useLayoutEffect(() => {
-    return () => void store.unsubscribe(listener.current)
+    return () => {
+      store.unsubscribe(listener.current)
+    }
   }, [store])
 
   return new Proxy<Record<any, any>>(


### PR DESCRIPTION
This fixes a race condition issue where a component would have subscribed to store updates in a layout effect and missed updates to the store written _during the render/reconciliation phase_ (for example by an element invoking a function ref.)