### PR TITLE
Rerender on changes since reconciliation phase

### DIFF
--- a/.changeset/wicked-roses-switch.md
+++ b/.changeset/wicked-roses-switch.md
@@ -1,0 +1,5 @@
+---
+"statery": patch
+---
+
+`useStore` will now force the component to re-render if a change was detected between the React render/reconcile stage and the invocation of the layout effect that actually sets up the subscription listener. This improves reactivity in situations where values were changed in the store during the render phase, or imperatively from outside of your React component tree.

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,7 +194,6 @@ export const useStore = <T extends State>(store: Store<T>): T => {
 
     /* Mount & unmount the listener */
     store.subscribe(listener)
-
     return () => void store.unsubscribe(listener)
   }, [store])
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,6 +176,13 @@ export const useStore = <T extends State>(store: Store<T>): T => {
 
     /* Mount & unmount the listener */
     store.subscribe(listener)
+
+    /* Immediately bump the version to cause an initial re-render. Why are
+    we doing this? Because something might have changed in the store during
+    the same React render/reconciliation phase as this component (eg. through
+    a function ref.) */
+    setVersion((v) => v + 1)
+
     return () => void store.unsubscribe(listener)
   }, [store])
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,9 @@ export const useStore = <T extends State>(store: Store<T>): T => {
   /* A set containing all props that we're interested in. */
   const subscribedProps = useConst(() => new Set<keyof T>())
 
+  /* Get a copy of the state when the component is rendering. */
+  const initialState = useConst(() => ({ ...store.state }))
+
   /* Subscribe to changes in the store. */
   useLayoutEffect(() => {
     const listener: Listener<T> = (updates: Partial<T>) => {
@@ -181,7 +184,10 @@ export const useStore = <T extends State>(store: Store<T>): T => {
     we doing this? Because something might have changed in the store during
     the same React render/reconciliation phase as this component (eg. through
     a function ref.) */
-    setVersion((v) => v + 1)
+
+    subscribedProps.forEach((prop) => {
+      if (initialState[prop] !== store.state[prop]) setVersion((v) => v + 1)
+    })
 
     return () => void store.unsubscribe(listener)
   }, [store])

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,6 +172,8 @@ export const useStore = <T extends State>(store: Store<T>): T => {
   const initialState = useConst(() => store.state)
 
   useLayoutEffect(() => {
+    if (store.state === initialState) return
+
     subscribedProps.forEach((prop) => {
       if (initialState[prop] !== store.state[prop]) {
         setVersion((v) => v + 1)

--- a/test/hooks.test.tsx
+++ b/test/hooks.test.tsx
@@ -134,9 +134,9 @@ describe("useStore", () => {
        renders everything twice. Also, we need to account for components doing
        an initial re-render to catch up with store updates that might have been
        written during the render and reconciliation phases (eg. through function refs.) */
-    expect(woodRenderCount).toEqual(10 * 2)
-    expect(housesRenderCount).toEqual(3 * 2)
-    expect(buttonsRenderCount).toEqual(10 * 2)
+    expect(woodRenderCount).toEqual(9 * 2)
+    expect(housesRenderCount).toEqual(2 * 2)
+    expect(buttonsRenderCount).toEqual(9 * 2)
   })
 
   it("should not re-render a component when a watched prop was updated to the same value", async () => {
@@ -170,15 +170,15 @@ describe("useStore", () => {
 
     const { getByText, findByText } = render(<Counter />)
 
-    expect(renders).toBe(2)
+    expect(renders).toBe(1)
     await findByText("Counter: 0")
     fireEvent.click(getByText("Increase Counter"))
 
-    expect(renders).toBe(3)
+    expect(renders).toBe(2)
     await findByText("Counter: 1")
     fireEvent.click(getByText("Set to Same Value"))
 
-    expect(renders).toBe(3)
+    expect(renders).toBe(2)
   })
 
   it("works with boolean state properties", async () => {

--- a/test/hooks.test.tsx
+++ b/test/hooks.test.tsx
@@ -131,9 +131,7 @@ describe("useStore", () => {
 
     /* Check how often each component was rendered. Since we're using React's
        StrictMode, we need to double these numbers because StrictMode intentionally
-       renders everything twice. Also, we need to account for components doing
-       an initial re-render to catch up with store updates that might have been
-       written during the render and reconciliation phases (eg. through function refs.) */
+       renders everything twice. */
     expect(woodRenderCount).toEqual(9 * 2)
     expect(housesRenderCount).toEqual(2 * 2)
     expect(buttonsRenderCount).toEqual(9 * 2)

--- a/test/hooks.test.tsx
+++ b/test/hooks.test.tsx
@@ -131,10 +131,12 @@ describe("useStore", () => {
 
     /* Check how often each component was rendered. Since we're using React's
        StrictMode, we need to double these numbers because StrictMode intentionally
-       renders everything twice. */
-    expect(woodRenderCount).toEqual(9 * 2)
-    expect(housesRenderCount).toEqual(2 * 2)
-    expect(buttonsRenderCount).toEqual(9 * 2)
+       renders everything twice. Also, we need to account for components doing
+       an initial re-render to catch up with store updates that might have been
+       written during the render and reconciliation phases (eg. through function refs.) */
+    expect(woodRenderCount).toEqual(10 * 2)
+    expect(housesRenderCount).toEqual(3 * 2)
+    expect(buttonsRenderCount).toEqual(10 * 2)
   })
 
   it("should not re-render a component when a watched prop was updated to the same value", async () => {
@@ -168,15 +170,15 @@ describe("useStore", () => {
 
     const { getByText, findByText } = render(<Counter />)
 
-    expect(renders).toBe(1)
+    expect(renders).toBe(2)
     await findByText("Counter: 0")
     fireEvent.click(getByText("Increase Counter"))
 
-    expect(renders).toBe(2)
+    expect(renders).toBe(3)
     await findByText("Counter: 1")
     fireEvent.click(getByText("Set to Same Value"))
 
-    expect(renders).toBe(2)
+    expect(renders).toBe(3)
   })
 
   it("works with boolean state properties", async () => {


### PR DESCRIPTION
A component that uses `useStore` to consume a store will subscribe to it within a layout effect, but it's possible that writes might happen between the React render & reconcile stages and the invocation of that effect. These writes would previously have been missed, but this change fixes that by setting up another layout effect that specifically tests for changes having arrived since the render stage, and re-renders the component if one is detected.