### PR TITLE
Fix getServerSnapshot

### DIFF
--- a/.changeset/itchy-monkeys-check.md
+++ b/.changeset/itchy-monkeys-check.md
@@ -1,0 +1,5 @@
+---
+"statery": patch
+---
+
+Fixes SSR issue with Next.js requiring the getServerSnapshot argument with useSyncExternalStore.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "clean": "rimraf dist",
     "dev": "preconstruct dev",
     "build": "preconstruct build",
-    "test": "jest",
+    "test:client": "jest --testPathIgnorePatterns=.server.test",
+    "test:server": "jest --testPathPattern=.server.test --env=node",
+    "test": "pnpm test:client && pnpm test:server",
     "ci:test": "preconstruct validate && pnpm build && pnpm test",
     "ci:version": "changeset version && pnpm install --no-frozen-lockfile",
     "ci:release": "pnpm ci:test && pnpm changeset publish"

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,7 +192,8 @@ export const useStore = <T extends IState>(store: Store<T>): T => {
     return prevSnapshot.current
   }, [store])
 
-  const snapshot = useSyncExternalStore(subscribe, getSnapshot)
+  /* Pass getSnapshot to the "getServerSnapshot" argument to prevent SSR crash in Next.js */
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
 
   return new Proxy<Record<any, any>>(
     {},

--- a/test/hooks.server.test.tsx
+++ b/test/hooks.server.test.tsx
@@ -1,0 +1,30 @@
+import React from "react"
+import { renderToPipeableStream } from "react-dom/server"
+import { PassThrough } from "stream"
+import { makeStore, useStore } from "../src"
+
+function renderServerSide(element: React.ReactElement) {
+  return new Promise<string>((resolve, reject) => {
+    let result = ""
+    renderToPipeableStream(element)
+      .pipe(new PassThrough())
+      .on("data", (chunk) => (result += chunk))
+      .on("end", () => resolve(result))
+      .on("error", reject)
+  })
+}
+
+describe("useStore", () => {
+  it("renders server-side", async () => {
+    const store = makeStore({ ssr: "yep" })
+
+    const SSRComponent = () => {
+      const { ssr } = useStore(store)
+      return <div>{ssr}</div>
+    }
+
+    const html = await renderServerSide(<SSRComponent />)
+
+    expect(html).toEqual("<div>yep</div>")
+  })
+})


### PR DESCRIPTION
Fixes #30 by passing `getSnapshot` to `getServerSnapshot`, similar to [Apollo's fix](https://github.com/apollographql/apollo-client/pull/9652/files) linked in [the original issue](https://github.com/hmans/statery/issues/30#issue-1870586367).

Added test-case (and verified it fails before the code-change) to prevent it from happening again.